### PR TITLE
Add confluence link to PR standards

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+[PR Guidelines](https://technologyadvice.atlassian.net/wiki/spaces/EN/pages/962560174/PR+Documentation+Review+Guidelines)
+
 ### Description
 
 ### Related issue(s)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-[PR Guidelines](https://technologyadvice.atlassian.net/wiki/spaces/EN/pages/962560174/PR+Documentation+Review+Guidelines)
+Please follow our [PR Guidelines](https://technologyadvice.atlassian.net/wiki/spaces/EN/pages/962560174/PR+Documentation+Review+Guidelines) for submitting or reviewing a PR
 
 ### Description
 


### PR DESCRIPTION
[PR Guidelines](https://technologyadvice.atlassian.net/wiki/spaces/EN/pages/962560174/PR+Documentation+Review+Guidelines)

### Description
Adding the link above to the template. There isn't a great way to test this other than the link I've included above.

### Related issue(s)

### Related PR(s)

### How to test / repro

### Screenshots
![image](https://user-images.githubusercontent.com/37662219/118128617-c2e7dc80-b3c0-11eb-8833-8577216de632.png)

### Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

### Checklist
- [ ] I have tested this code
- [ ] If this is a bugfix, I've added testing to check this in the future
- [ ] I have updated the Readme
- [ ] I have added appropriate logging at the correct levels
